### PR TITLE
- Fixed tests to update phpunit 6.0

### DIFF
--- a/Tests/ConstantTest.php
+++ b/Tests/ConstantTest.php
@@ -8,9 +8,11 @@
 
 namespace Skilla\ValidatorCifNifNie\Test;
 
+use PHPUnit\Framework\TestCase;
 use Skilla\ValidatorCifNifNie\Constant;
 
-class ConstantTest extends \PHPUnit_Framework_TestCase
+
+class ConstantTest extends TestCase
 {
     public function testRetrievePattern()
     {

--- a/Tests/GeneratorTest.php
+++ b/Tests/GeneratorTest.php
@@ -9,8 +9,9 @@
 namespace Skilla\ValidatorCifNifNie\Test;
 
 use Skilla\ValidatorCifNifNie\Generator;
+use PHPUnit\Framework\TestCase;
 
-class GeneratorTest extends \PHPUnit_Framework_TestCase
+class GeneratorTest extends TestCase
 {
     /**
      * @expectedException \Skilla\ValidatorCifNifNie\InvalidParameterException

--- a/Tests/ValidatorTest.php
+++ b/Tests/ValidatorTest.php
@@ -10,8 +10,9 @@ namespace Skilla\ValidatorCifNifNie\Test;
 
 use Skilla\ValidatorCifNifNie\Generator;
 use Skilla\ValidatorCifNifNie\Validator;
+use PHPUnit\Framework\TestCase;
 
-class ValidatorTest extends \PHPUnit_Framework_TestCase
+class ValidatorTest extends TestCase
 {
     /**
      * @var Validator


### PR DESCRIPTION
Hola,

he probado hoy el código y al pasar los tests me daba un error. El caso es que en el composer.json hace un require de phpunit que normalmente instala o actualiza a la última versión disponible.

"require-dev": {
        "phpunit/phpunit": ">=4.5.0"
    },

La última versión es la 6.0 y ha cambiado la clase de la que se extiende al crear un test:  \PHPUnit_Framework_TestCase por esta otra TestCase.

He hecho las modificaciones pertinentes para que pasen los tests nuevamente.