### PR TITLE
Fix PHP 8.2 deprecation message by declaring property

### DIFF
--- a/src/Validator.php
+++ b/src/Validator.php
@@ -14,6 +14,11 @@ class Validator
     const DOCUMENT_LENGTH_WITHOUT_CODE = 8;
 
     /**
+     * @var Generator
+     */
+    private $generator;
+
+    /**
      * @param Generator $generator
      */
     public function __construct($generator)


### PR DESCRIPTION
This PR fixes the following deprecation message with PHP 8.2:
```
Creation of dynamic property Skilla\ValidatorCifNifNie\Validator::$generator is deprecated
```